### PR TITLE
Check if *.def files are Modula-2

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -347,6 +347,31 @@ const char *disambiguate_cs(SourceFile *sourcefile) {
     return LANG_CSHARP;
 }
 
+const char *disambiguate_def(SourceFile *sourcefile) {
+  char *p = ohcount_sourcefile_get_contents(sourcefile);
+  char *eof = p + ohcount_sourcefile_get_contents_size(sourcefile);
+  for (; p < eof; p++) {
+    switch (*p) {
+    case ' ':
+    case '\t':
+    case '\n':
+    case '\r':
+      break;
+    case '(':
+      if (p[1] == '*') // Modula-2 comment
+        return LANG_MODULA2;
+      return NULL;
+    case 'D':
+      if (strncmp(p, "DEFINITION", 10) == 0) // Modula-2 "DEFINITION MODULE"
+        return LANG_MODULA2;
+      return NULL;
+    default:
+      return NULL; // not Modula-2
+    }
+  }
+  return NULL; // only blanks
+}
+
 const char *disambiguate_fortran(SourceFile *sourcefile) {
   char *p, *pe;
 

--- a/src/hash/disambiguatefuncs.gperf
+++ b/src/hash/disambiguatefuncs.gperf
@@ -7,6 +7,7 @@ const char *disambiguate_asx(SourceFile *sourcefile);
 const char *disambiguate_b(SourceFile *sourcefile);
 const char *disambiguate_basic(SourceFile *sourcefile);
 const char *disambiguate_cs(SourceFile *sourcefile);
+const char *disambiguate_def(SourceFile *sourcefile);
 const char *disambiguate_fortran(SourceFile *sourcefile);
 const char *disambiguate_h(SourceFile *sourcefile);
 const char *disambiguate_in(SourceFile *sourcefile);
@@ -24,6 +25,7 @@ asx, disambiguate_asx
 b, disambiguate_b
 basic, disambiguate_basic
 cs, disambiguate_cs
+def, disambiguate_def
 fortran, disambiguate_fortran
 h, disambiguate_h
 in, disambiguate_in

--- a/src/hash/extensions.gperf
+++ b/src/hash/extensions.gperf
@@ -48,7 +48,7 @@ cu, LANG_CUDA
 cxx, LANG_CPP
 d, LANG_DMD
 dat, BINARY
-def, LANG_MODULA2
+def, DISAMBIGUATE("def")
 di, LANG_DMD
 doc, BINARY
 dylan, LANG_DYLAN

--- a/test/detect_files/module-definition.def
+++ b/test/detect_files/module-definition.def
@@ -1,0 +1,5 @@
+EXPORTS
+	DllCanUnloadNow		PRIVATE
+	DllGetClassObject	PRIVATE
+	DllRegisterServer	PRIVATE
+	DllUnregisterServer	PRIVATE

--- a/test/detect_files/sampleDef.def
+++ b/test/detect_files/sampleDef.def
@@ -1,0 +1,12 @@
+DEFINITION MODULE Sample; (* in Modula-2 *)
+
+(* This is a comment *)
+
+(* This is a comment ...
+   ... spanning more than one line *)
+
+CONST
+  sqString = 'this is a string within "a string" ...';
+  dqString = "this is a string within 'a string' ...";
+  
+END Sample.

--- a/test/unit/detector_test.h
+++ b/test/unit/detector_test.h
@@ -64,6 +64,11 @@ void test_detector_disambiguate_asx() {
   ASSERT_NODETECT("AdvancedStreamRedirector.asx");
 }
 
+void test_detector_disambiguate_def() {
+  ASSERT_DETECT(LANG_MODULA2, "sampleDef.def");
+  ASSERT_NODETECT("module-definition.def");
+}
+
 void test_detector_disambiguate_m() {
   ASSERT_DETECT(LANG_OBJECTIVE_C, "t1.m");
   ASSERT_DETECT(LANG_OBJECTIVE_C, "t2.m");
@@ -180,6 +185,7 @@ void test_detector_emacs_mode() {
 void all_detector_tests() {
   test_detector_smalltalk();
   test_detector_disambiguate_asx();
+  test_detector_disambiguate_def();
   test_detector_disambiguate_m();
   test_detector_disambiguate_in();
   test_detector_disambiguate_pro();


### PR DESCRIPTION
Hello,

Currently ohcount assumes that all *.def files are Modula-2.
On Windows, *.def files are likely to be linker scripts ("module-definition files" in Microsoft terminology). Typically they list functions exported from a DLL.

My patch checks if a *.def file starts like a Modula-2 definition module by looking for the leading "DEFINITION" keyword or "(\* Modula-2 comment *)". I believe this is correct detection, however I'm no Modula-2 expert. :)

Piotr
