### PR TITLE
Fix a crash when encountering an empty .r file

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -746,7 +746,7 @@ const char *disambiguate_r(SourceFile *sourcefile) {
   // block.
   char *needle = "rebol";
   int len = strlen(needle);
-  for (; contents < eof - len; ++contents)
+  for (; contents && contents < eof - len; ++contents)
     if (tolower(*contents) == *needle &&
           !strncasecmp(contents, needle, len))
       return LANG_REBOL;


### PR DESCRIPTION
When ohcount encounters an .r file, it tries to see if it's a rebol file.  There's a crash bug however since the disambiguate_r function doesn't correctly handle the case of empty .r files, which causes a null pointer to be dereferenced (because eof - len would be an extremely large number, and contents is always going to be smaller than that, so the body of the for loop is entered.

I found this bug when I tried running ohcount on the current WebKit repository.
