### PR TITLE
OTWO-1300 Improves *.pl disambiguation to ignore smileys :-)

### DIFF
--- a/test/detect_files/perl_shebang_prolog_body.pl
+++ b/test/detect_files/perl_shebang_prolog_body.pl
@@ -1,0 +1,3 @@
+#!%PERL%
+% This is prolog code, but the shebang says perl, so we respect the shebang and choose perl.
+Head :- Body.

--- a/test/detect_files/perl_with_smiley.pl
+++ b/test/detect_files/perl_with_smiley.pl
@@ -1,0 +1,2 @@
+# This is not prolog. Do not be confused by the smiley, which looks like a Prolog rule.
+print "Hello, world :-)\n"

--- a/test/unit/detector_test.h
+++ b/test/unit/detector_test.h
@@ -86,6 +86,8 @@ void test_detector_disambiguate_pl() {
   ASSERT_DETECT(LANG_PERL, "foo_perl1.pl");
   ASSERT_DETECT(LANG_PERL, "foo_perl2.pl");
   ASSERT_DETECT(LANG_PROLOG, "foo_prolog1.pl");
+  ASSERT_DETECT(LANG_PERL, "perl_with_smiley.pl");
+  ASSERT_DETECT(LANG_PERL, "perl_shebang_prolog_body.pl");
 }
 
 void test_detector_disambiguate_pro() {


### PR DESCRIPTION
Smiley faces in Perl strings and comments look similar to Prolog
rule syntax. This patch makes two improvements:
- Better detection of perl shebangs (#!%PERL% now recognized)
- A prolog ':-' token must be followed by a space or a newline
