### PR TITLE
Initial support for Forth

### DIFF
--- a/src/hash/extensions.gperf
+++ b/src/hash/extensions.gperf
@@ -6,6 +6,7 @@
 %}
 struct ExtensionMap { const char *key; const char *value; };
 %%
+4th, LANG_FORTH
 C, LANG_CPP
 H, LANG_CPP
 ada, LANG_ADA
@@ -67,6 +68,7 @@ f77, DISAMBIGUATE("fortran")
 f90, DISAMBIGUATE("fortran")
 f95, DISAMBIGUATE("fortran")
 factor, LANG_FACTOR
+fr, LANG_FORTH
 frag, LANG_GLSL
 frm, LANG_VISUALBASIC
 frx, LANG_VISUALBASIC

--- a/src/hash/languages.gperf
+++ b/src/hash/languages.gperf
@@ -38,6 +38,7 @@ emacslisp, LANG_EMACSLISP, "Emacs lisp", 0
 erlang, LANG_ERLANG, "Erlang", 0
 exheres, LANG_EXHERES, "Exheres", 0
 factor, LANG_FACTOR, "Factor", 0
+forth, LANG_FORTH, "Forth", 0
 fortranfixed, LANG_FORTRANFIXED, "Fortan (Fixed-format)", 0
 fortranfree, LANG_FORTRANFREE, "Fortan (Free-format)", 0
 fsharp, LANG_FSHARP, "F#", 0

--- a/src/hash/parsers.gperf
+++ b/src/hash/parsers.gperf
@@ -27,6 +27,7 @@
 #include "../parsers/erlang.h"
 #include "../parsers/exheres.h"
 #include "../parsers/factor.h"
+#include "../parsers/forth.h"
 #include "../parsers/fortranfixed.h"
 #include "../parsers/fortranfree.h"
 #include "../parsers/fsharp.h"
@@ -127,6 +128,7 @@ erlang, parse_erlang
 exheres, parse_exheres
 emacslisp, parse_emacslisp
 factor, parse_factor
+forth, parse_forth
 fortranfixed, parse_fortranfixed
 fortranfree, parse_fortranfree
 fsharp, parse_fsharp

--- a/src/languages.h
+++ b/src/languages.h
@@ -40,6 +40,7 @@
 #define LANG_EXHERES "exheres"
 #define LANG_EMACSLISP "emacslisp"
 #define LANG_FACTOR "factor"
+#define LANG_FORTH "forth"
 #define LANG_FORTRANFIXED "fortranfixed"
 #define LANG_FORTRANFREE "fortranfree"
 #define LANG_FSHARP "fsharp"

--- a/src/parsers/forth.rl
+++ b/src/parsers/forth.rl
@@ -1,0 +1,117 @@
+// forth.rl 
+// derived from code written by Mitchell Foral. mitchell<att>caladbolg<dott>net.
+
+/************************* Required for every parser *************************/
+#ifndef OHCOUNT_FORTH_PARSER_H
+#define OHCOUNT_FORTH_PARSER_H
+
+#include "../parser_macros.h"
+
+// the name of the language
+const char *FORTH_LANG = LANG_FORTH;
+
+// the languages entities
+const char *forth_entities[] = {
+  "space", "comment", "string", "any",
+};
+
+// constants associated with the entities
+enum {
+  FORTH_SPACE = 0, FORTH_COMMENT, FORTH_STRING, FORTH_ANY
+};
+
+/*****************************************************************************/
+
+%%{
+  machine forth;
+  write data;
+  include common "common.rl";
+
+  # Line counting machine
+
+  action forth_ccallback {
+    switch(entity) {
+    case FORTH_SPACE:
+      ls
+      break;
+    case FORTH_ANY:
+      code
+      break;
+    case INTERNAL_NL:
+      std_internal_newline(FORTH_LANG)
+      break;
+    case NEWLINE:
+      std_newline(FORTH_LANG)
+    }
+  }
+
+  forth_line_comment = '\\' @comment nonnewline*;
+  forth_block_comment =
+    '(' @comment (
+      newline %{ entity = INTERNAL_NL; } %forth_ccallback
+      |
+      ws
+      |
+      (nonnewline - ws) @comment
+    )* :>> ')';
+  forth_comment = forth_line_comment | forth_block_comment;
+
+  forth_string = '"' @code ([^\r\n\f"])* '"';
+
+  forth_line := |*
+    spaces         ${ entity = FORTH_SPACE; } => forth_ccallback;
+    forth_comment;
+    forth_string;
+    newline        ${ entity = NEWLINE;     } => forth_ccallback;
+    ^space         ${ entity = FORTH_ANY;   } => forth_ccallback;
+  *|;
+
+  # Entity machine
+
+  action forth_ecallback {
+    callback(FORTH_LANG, forth_entities[entity], cint(ts), cint(te), userdata);
+  }
+
+  forth_line_comment_entity = '\\' nonnewline*;
+  forth_block_comment_entity = '(' any* :>> ')';
+  forth_comment_entity = forth_line_comment_entity | forth_block_comment_entity;
+
+  forth_entity := |*
+    space+               ${ entity = FORTH_SPACE;   } => forth_ecallback;
+    forth_comment_entity ${ entity = FORTH_COMMENT; } => forth_ecallback;
+    # TODO:
+    ^space;
+  *|;
+}%%
+
+/************************* Required for every parser *************************/
+
+/* Parses a string buffer with Forth code.
+ *
+ * @param *buffer The string to parse.
+ * @param length The length of the string to parse.
+ * @param count Integer flag specifying whether or not to count lines. If yes,
+ *   uses the Ragel machine optimized for counting. Otherwise uses the Ragel
+ *   machine optimized for returning entity positions.
+ * @param *callback Callback function. If count is set, callback is called for
+ *   every line of code, comment, or blank with 'lcode', 'lcomment', and
+ *   'lblank' respectively. Otherwise callback is called for each entity found.
+ */
+void parse_forth(char *buffer, int length, int count,
+                 void (*callback) (const char *lang, const char *entity, int s,
+                                   int e, void *udata),
+                 void *userdata
+  ) {
+  init
+
+  %% write init;
+  cs = (count) ? forth_en_forth_line : forth_en_forth_entity;
+  %% write exec;
+
+  // if no newline at EOF; callback contents of last line
+  if (count) { process_last_line(FORTH_LANG) }
+}
+
+#endif
+
+/*****************************************************************************/

--- a/test/detect_files/forth.4th
+++ b/test/detect_files/forth.4th
@@ -1,0 +1,7 @@
+\ Sample Forth code
+
+( This is a comment
+  spanning multiple lines )
+
+: somedefinition ;
+

--- a/test/detect_files/forth.fr
+++ b/test/detect_files/forth.fr
@@ -1,0 +1,7 @@
+\ Sample Forth code
+
+( This is a comment
+  spanning multiple lines )
+
+: somedefinition ;
+

--- a/test/expected_dir/forth.4th
+++ b/test/expected_dir/forth.4th
@@ -1,0 +1,7 @@
+forth	comment	\ Sample Forth code
+forth	blank	
+forth	comment	( This is a comment
+forth	comment	  spanning multiple lines )
+forth	blank	
+forth	code	: somedefinition ;
+forth	blank	

--- a/test/src_dir/forth.4th
+++ b/test/src_dir/forth.4th
@@ -1,0 +1,7 @@
+\ Sample Forth code
+
+( This is a comment
+  spanning multiple lines )
+
+: somedefinition ;
+

--- a/test/unit/detector_test.h
+++ b/test/unit/detector_test.h
@@ -139,6 +139,8 @@ void test_detector_detect_polyglot() {
   ASSERT_DETECT(LANG_IDL_PVWAVE, "foo.pro");
   ASSERT_DETECT(LANG_ASSEMBLER, "foo.z80");
   ASSERT_DETECT(LANG_PHP, "php.inc");
+  ASSERT_DETECT(LANG_FORTH, "forth.4th");
+  ASSERT_DETECT(LANG_FORTH, "forth.fr");
   ASSERT_DETECT(LANG_FSHARP, "fs1.fs");
   ASSERT_DETECT(LANG_AUTOCONF, "m4.m4");
   ASSERT_DETECT(LANG_NSIS, "foo.nsi");

--- a/test/unit/parser_test.h
+++ b/test/unit/parser_test.h
@@ -102,6 +102,7 @@ void test_parser_verify_entity(SourceFile *sf, const char *entity,
 #include "parsers/test_erlang.h"
 #include "parsers/test_exheres.h"
 #include "parsers/test_factor.h"
+#include "parsers/test_forth.h"
 #include "parsers/test_fortran.h"
 #include "parsers/test_fsharp.h"
 #include "parsers/test_glsl.h"
@@ -283,6 +284,7 @@ void all_parser_tests() {
   all_erlang_tests();
   all_exheres_tests();
   all_factor_tests();
+  all_forth_tests();
   all_fortran_tests();
   all_fsharp_tests();
   all_glsl_tests();

--- a/test/unit/parsers/test_forth.h
+++ b/test/unit/parsers/test_forth.h
@@ -1,0 +1,15 @@
+
+void test_forth_comment_entities() {
+  test_parser_verify_entity(
+    test_parser_sourcefile("forth", " \\comment"),
+    "comment", "\\comment"
+  );
+  test_parser_verify_entity(
+    test_parser_sourcefile("forth", " (comment)"),
+    "comment", "(comment)"
+  );
+}
+
+void all_forth_tests() {
+  test_forth_comment_entities();
+}


### PR DESCRIPTION
This is based on the Scala parser, which is actually quite
incorrect -- assumes existence of single-quote strings (which
will cause problem on any file with symbols), doesn't know
multiline strings, doesn't handle nested comments: all of which
made it a pretty good starting point for Forth.

Parsing Forth is impossible, but this will recognize comments,
strings and blank lines on most projects. Tested against FreeBSD
source.
