### PR TITLE
Improve detection of Puppet PP files

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -797,7 +797,7 @@ const char *disambiguate_pp(SourceFile *sourcefile) {
 
 	/* check for standard puppet constructs */
 	pcre *construct;
-	construct = pcre_compile("^\\s*(define\\s+[\\w:-]+\\s*\\(|class\\s+[\\w:-]+(\\s+inherits\\s+[\\w:-]+)?\\s*{|node\\s+\\'?[\\w:\\.-]+\\'?\\s*{)",
+	construct = pcre_compile("^\\s*(define\\s+[\\w:-]+\\s*\\(|class\\s+[\\w:-]+(\\s+inherits\\s+[\\w:-]+)?\\s*{|node\\s+\\'?[\\w:\\.-]+\\'?\\s*{|import\\s+\")",
 			PCRE_MULTILINE, &error, &erroffset, NULL);
 
 	if (pcre_exec(construct, NULL, p, mystrnlen(p, 10000), 0, 0, NULL, 0) > -1)


### PR DESCRIPTION
Fix a couple of bugs in the regex tie breaker for pp files, and add one more test to catch a common type of Puppet file that the existing regex didn't catch.
