### PR TITLE
Specify ruby version, gpref, and libmagic in build requirements docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Ohcount source code is available as a Git repository:
 Building Ohcount
 ----------------
 
-You will need ragel 6.3 or higher, bash, pcre, magic, gcc (version 4.1.2 or greater)
-and SWIG. Once you have them, go to the top directory of ohcount and run
+You will need ruby 1.8.7, ragel 6.3 or higher, bash, pcre, libmagic, gcc (version 4.1.2 or greater),
+gperf, and SWIG. Once you have them, go to the top directory of ohcount and run
 
 ```
 ./build


### PR DESCRIPTION
Clarify that you must have ruby 1.8.7, add gperf, and "magic" is really libmagic.
