### PR TITLE
Add Grace language

### DIFF
--- a/src/hash/extensions.gperf
+++ b/src/hash/extensions.gperf
@@ -85,6 +85,8 @@ gif, BINARY
 glsl, LANG_GLSL
 go, LANG_GOLANG
 groovy, LANG_GROOVY
+grace, LANG_GRACE
+grc, LANG_GRACE
 gs, LANG_GENIE
 gz, BINARY
 h, DISAMBIGUATE("h")

--- a/src/hash/languages.gperf
+++ b/src/hash/languages.gperf
@@ -48,6 +48,7 @@ fsharp, LANG_FSHARP, "F#", 0
 genie, LANG_GENIE, "Genie", 0
 glsl, LANG_GLSL, "OpenGL Shading Language", 0
 golang, LANG_GOLANG, "Golang", 0
+grace, LANG_GRACE, "Grace", 0
 groovy, LANG_GROOVY, "Groovy", 0
 haml, LANG_HAML, "Haml", 1
 haskell, LANG_HASKELL, "Haskell", 0

--- a/src/hash/parsers.gperf
+++ b/src/hash/parsers.gperf
@@ -35,6 +35,7 @@
 #include "../parsers/fsharp.h"
 #include "../parsers/glsl.h"
 #include "../parsers/golang.h"
+#include "../parsers/grace.h"
 #include "../parsers/groovy.h"
 #include "../parsers/haml.h"
 #include "../parsers/haskell.h"
@@ -140,6 +141,7 @@ fsharp, parse_fsharp
 genie, parse_genie
 glsl, parse_glsl
 golang, parse_golang
+grace, parse_grace
 groovy, parse_groovy
 haskell, parse_haskell
 haml, parse_haml

--- a/src/languages.h
+++ b/src/languages.h
@@ -49,6 +49,7 @@
 #define LANG_GENIE "genie"
 #define LANG_GLSL "glsl"
 #define LANG_GOLANG "golang"
+#define LANG_GRACE "grace"
 #define LANG_GROOVY "groovy"
 #define LANG_HASKELL "haskell"
 #define LANG_HAML "haml"

--- a/src/parsers/grace.rl
+++ b/src/parsers/grace.rl
@@ -1,0 +1,113 @@
+// grace.rl written by Michael Homer, based on shell.rl
+// by Mitchell Foral. mitchell<att>caladbolg<dott>net
+
+/************************* Required for every parser *************************/
+#ifndef OHCOUNT_GRACE_PARSER_H
+#define OHCOUNT_GRACE_PARSER_H
+
+#include "../parser_macros.h"
+
+// the name of the language
+const char *GRACE_LANG = LANG_GRACE;
+
+// the languages entities
+const char *grace_entities[] = {
+  "space", "comment", "string", "any"
+};
+
+// constants associated with the entities
+enum {
+  GRACE_SPACE = 0, GRACE_COMMENT, GRACE_STRING, GRACE_ANY
+};
+
+/*****************************************************************************/
+
+%%{
+  machine grace;
+  write data;
+  include common "common.rl";
+
+  # Line counting machine
+
+  action grace_ccallback {
+    switch(entity) {
+    case GRACE_SPACE:
+      ls
+      break;
+    case GRACE_ANY:
+      code
+      break;
+    case INTERNAL_NL:
+      std_internal_newline(GRACE_LANG)
+      break;
+    case NEWLINE:
+      std_newline(GRACE_LANG)
+    }
+  }
+
+  grace_comment = '//' @comment nonnewline*;
+
+  grace_string =
+    '"' @enqueue @code (
+      newline %{ entity = INTERNAL_NL; } %grace_ccallback
+      |
+      ws
+      |
+      [^\r\n\f\t "\\] @code
+    )* '"' @commit;
+
+  grace_line := |*
+    spaces         ${ entity = GRACE_SPACE; } => grace_ccallback;
+    grace_comment;
+    grace_string;
+    newline        ${ entity = NEWLINE;     } => grace_ccallback;
+    ^space         ${ entity = GRACE_ANY;   } => grace_ccallback;
+  *|;
+
+  # Entity machine
+
+  action grace_ecallback {
+    callback(GRACE_LANG, grace_entities[entity], cint(ts), cint(te), userdata);
+  }
+
+  grace_comment_entity = '//' nonnewline*;
+
+  grace_entity := |*
+    space+               ${ entity = GRACE_SPACE;   } => grace_ecallback;
+    grace_comment_entity ${ entity = GRACE_COMMENT; } => grace_ecallback;
+    # TODO:
+    ^space;
+  *|;
+}%%
+
+/************************* Required for every parser *************************/
+
+/* Parses a string buffer with Grace code.
+ *
+ * @param *buffer The string to parse.
+ * @param length The length of the string to parse.
+ * @param count Integer flag specifying whether or not to count lines. If yes,
+ *   uses the Ragel machine optimized for counting. Otherwise uses the Ragel
+ *   machine optimized for returning entity positions.
+ * @param *callback Callback function. If count is set, callback is called for
+ *   every line of code, comment, or blank with 'lcode', 'lcomment', and
+ *   'lblank' respectively. Otherwise callback is called for each entity found.
+ */
+void parse_grace(char *buffer, int length, int count,
+                 void (*callback) (const char *lang, const char *entity, int s,
+                                   int e, void *udata),
+                 void *userdata
+  ) {
+  init
+
+  %% write init;
+  cs = (count) ? grace_en_grace_line : grace_en_grace_entity;
+  %% write exec;
+
+  // if no newline at EOF; callback contents of last line
+  if (count) { process_last_line(GRACE_LANG) }
+}
+
+#endif
+
+/*****************************************************************************/

--- a/test/expected_dir/grace.grace
+++ b/test/expected_dir/grace.grace
@@ -1,0 +1,2 @@
+grace	lcomment	// Sample Grace code
+grace	lcode	print "OK"

--- a/test/src_dir/grace.grace
+++ b/test/src_dir/grace.grace
@@ -1,0 +1,2 @@
+// Sample Grace code
+print "OK"

--- a/test/unit/detector_test.h
+++ b/test/unit/detector_test.h
@@ -145,6 +145,7 @@ void test_detector_detect_polyglot() {
   ASSERT_DETECT(LANG_FORTH, "forth.4th");
   ASSERT_DETECT(LANG_FORTH, "forth.fr");
   ASSERT_DETECT(LANG_FSHARP, "fs1.fs");
+  ASSERT_DETECT(LANG_GRACE, "grace.grace");
   ASSERT_DETECT(LANG_AUTOCONF, "m4.m4");
   ASSERT_DETECT(LANG_NSIS, "foo.nsi");
   ASSERT_DETECT(LANG_NSIS, "foo.nsh");


### PR DESCRIPTION
Add detection, parsing, and a test for Grace, an educational programming language. See http://gracelang.org/.

I have not been able to run all the tests because of the error identified in a previous pull request, so it's possible that that is broken somehow. The detection and counting performs accurately, though, so the first commit at least is fine.
