### PR TITLE
Handle magic descriptions like "PHP script, ASCII text".

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -50,7 +50,10 @@ const char *magic_parse(char *line) {
       struct LanguageMap *rl = ohcount_hash_language_from_name(buf, length);
       if (rl) return(rl->name);
     }
-  } else if (p) { // /(\w+)(?: -\w+)* script text/
+    return NULL;
+  }
+  p = strstr(line, "script");
+  if (p) { // /(\w+)(?: -\w+)* script(?: text)?/
     do {
       p--;
       pe = p;


### PR DESCRIPTION
libmagic version 5.11 and possibly other versions return descriptions in the format `<language> script, ASCII text (executable)?`. For example:

    PHP script, ASCII text
    Python script, ASCII text executable
    Ruby script, ASCII text executable 

This was causing test failures such as

    run_tests: test/unit/detector_test.h:119: test_detector_detect_polyglot: Assertion `lang' failed.

The proposed PR fixes the issue by handling the new description format in `magic_parse`.