### PR TITLE
shell: Fix identification following escaped newlines

### DIFF
--- a/src/parsers/shell.rl
+++ b/src/parsers/shell.rl
@@ -50,6 +50,8 @@ enum {
     '\'' @enqueue @code (
       newline %{ entity = INTERNAL_NL; } %shell_ccallback
       |
+      '\\' newline %{ entity = INTERNAL_NL; } %shell_ccallback
+      |
       ws
       |
       [^\r\n\f\t '\\] @code
@@ -59,6 +61,8 @@ enum {
   shell_dq_str =
     '"' @enqueue @code (
       newline %{ entity = INTERNAL_NL; } %shell_ccallback
+      |
+      '\\' newline %{ entity = INTERNAL_NL; } %shell_ccallback
       |
       ws
       |

--- a/test/expected_dir/sh2.sh
+++ b/test/expected_dir/sh2.sh
@@ -1,0 +1,5 @@
+shell	code	var="\
+shell	code	Some string"
+shell	blank	
+shell	comment	# Now a comment
+shell	code	var="some new string"

--- a/test/src_dir/sh2.sh
+++ b/test/src_dir/sh2.sh
@@ -1,0 +1,5 @@
+var="\
+Some string"
+
+# Now a comment
+var="some new string"


### PR DESCRIPTION
When a string contains an escaped newline, the internal state gets
out-of-sync with the source, leading to comments being incorrectly
identified as code.

Handle '\' + newline specially in order to account for this.
