### PR TITLE
Add Puppet parameterized classes

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -797,8 +797,8 @@ const char *disambiguate_pp(SourceFile *sourcefile) {
 
 	/* check for standard puppet constructs */
 	pcre *construct;
-	construct = pcre_compile("^\\s*(define\\s+[\\w:-]+\\s*\\(|class\\s+[\\w:-]+(\\s+inherits\\s+[\\w:-]+)?\\s*{|node\\s+\\'?[\\w:\\.-]+\\'?\\s*{|import\\s+\")",
-			PCRE_MULTILINE, &error, &erroffset, NULL);
+	construct = pcre_compile("^\\s*(define\\s+[\\w:-]+\\s*\\(|class\\s+[\\w:-]+\\s*(\\(.*?\\))?(\\s*inherits\\s+[\\w:-]+)?\\s*{|node\\s+\\'?[\\w:\\.-]+\\'?\\s*{|import\\s+\")",
+			PCRE_MULTILINE|PCRE_DOTALL, &error, &erroffset, NULL);
 
 	if (pcre_exec(construct, NULL, p, mystrnlen(p, 10000), 0, 0, NULL, 0) > -1)
 		return LANG_PUPPET;

--- a/test/detect_files/puppet_test2.pp
+++ b/test/detect_files/puppet_test2.pp
@@ -1,0 +1,5 @@
+class main::sub (
+  $foo = undef,
+  $bar = "baz")inherits bar{
+  include substuff
+}

--- a/test/detect_files/puppet_test2_annotated.pp
+++ b/test/detect_files/puppet_test2_annotated.pp
@@ -1,0 +1,5 @@
+puppet  lcode class main::sub (
+puppet  lcode   $foo = undef,
+puppet  lcode   $bar = "baz")inherits bar{
+puppet  lcode   include substuff
+puppet  lcode }

--- a/test/unit/detector_test.h
+++ b/test/unit/detector_test.h
@@ -207,6 +207,7 @@ void test_detector_emacs_with_extension() {
 void test_detector_puppet(){
   ASSERT_DETECT(LANG_PUPPET, "puppet_import.pp");
   ASSERT_DETECT(LANG_PUPPET, "puppet_test.pp");
+  ASSERT_DETECT(LANG_PUPPET, "puppet_test2.pp");
 }
 
 void test_detector_genie(){


### PR DESCRIPTION
This change expands one of the regular expressions used to disambiguate
Puppet and Pascal files ending with ".pp". Without this, parameterized
Puppet classes do not match and end up being detected as Pascal.

I have confirmed that with this change `ohcount` matches everything in my
Puppet tree that it matched with the previous, plus all that it _should_ have
matched, save one -- a file with nothing but comments & blank lines.

Running `ohcount -d` on the existing and newly-added files
`test/detect_files/puppet_*.pp` detects them as Puppet files (except for
the _`_annotated`_ ones, which aren't actually Puppet anyway); it also does
not erroneously detect anything as Puppet.

I attempted to run `./build tests`, but it core dumps on both master and this branch.
