### PR TITLE
detect PKGBUILD as LANG_SHELL

### DIFF
--- a/src/hash/filenames.gperf
+++ b/src/hash/filenames.gperf
@@ -18,3 +18,4 @@ Rakefile, LANG_RUBY
 rakefile, LANG_RUBY
 Gemfile, LANG_RUBY
 Vagrantfile, LANG_RUBY
+PKGBUILD, LANG_SHELL


### PR DESCRIPTION
Arch Linux uses PKGBUILD as build scripts, and they are actually written in Bash. The build tool (makepkg) will source the file and react accordingly.

Since currently all commits with PKGBUILD are not detected ("No source code was detected in this file"), I would like to suggest this line in filenames.gperf as a workaround.
