### PR TITLE
Try harder to disambiguate Puppet from Pascal

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -800,7 +800,7 @@ const char *disambiguate_pp(SourceFile *sourcefile) {
 
 	/* check for standard puppet constructs */
 	pcre *construct;
-	construct = pcre_compile("^\\s*(define\\s+[\\w:-]+\\s*\\(|class\\s+[\\w:-]+(\\s+inherits\\s+[\\w:-]+)?\\s*{|node\\s+\\'?[\\w:\\.-]+\\'?\\s*{|import\\s+\")",
+	construct = pcre_compile("^\\s*(define\\s+[\\w:-]+\\s*\\(|class\\s+[\\w:-]+(\\s+inherits\\s+[\\w:-]+)?\\s*[\\({]|node\\s+\\'?[\\w:\\.-]+\\'?\\s*{|import\\s+\"|include\\s+[\"']?[\\w:-][\"']?)",
 			PCRE_MULTILINE, &error, &erroffset, NULL);
 
 	if (pcre_exec(construct, NULL, p, mystrnlen(p, 10000), 0, 0, NULL, 0) > -1)


### PR DESCRIPTION
These two constructs are considered Puppet code:

```
class <word> (
```

and

```
include <word>
```
