### PR TITLE
Better Forth detection, in particular for .fs files

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -404,6 +404,37 @@ const char *disambiguate_def(SourceFile *sourcefile) {
   return NULL; // only blanks
 }
 
+const char *disambiguate_fs(SourceFile *sourcefile) {
+  /* .fs could be Forth or F# */
+  char *contents = ohcount_sourcefile_get_contents(sourcefile);
+  if (contents == NULL)
+    return NULL;
+  char *p = contents;
+  char c = *p;
+  long forthcount=0;
+  long fsharpcount=0;
+  while (c != '\0') {
+    while (c == ' ' || c == '\t')
+      c = *++p;
+    if (strncmp(p,"\\ ",2)==0) forthcount++;
+    else if (strncmp(p,": ",2)==0) forthcount++;
+    else if (strncmp(p,"|",1)==0) fsharpcount++;
+    else if (strncmp(p,"let ",4)==0) fsharpcount++;
+    else if (strncmp(p,"type ",5)==0) fsharpcount++;
+    else if (strncmp(p,"//",2)==0) fsharpcount++;
+    while (c != '\0' && c != '\n' && c != '\r')
+      c = *++p;
+    while (c == '\n' || c == '\r')
+      c = *++p;
+  }
+  if (forthcount > fsharpcount)
+    return LANG_FORTH;
+  else if (forthcount < fsharpcount)
+    return LANG_FSHARP;
+  else
+    return NULL;
+}    
+
 const char *disambiguate_fortran(SourceFile *sourcefile) {
   char *p;
 

--- a/src/hash/disambiguatefuncs.gperf
+++ b/src/hash/disambiguatefuncs.gperf
@@ -9,6 +9,7 @@ const char *disambiguate_basic(SourceFile *sourcefile);
 const char *disambiguate_cs(SourceFile *sourcefile);
 const char *disambiguate_def(SourceFile *sourcefile);
 const char *disambiguate_fortran(SourceFile *sourcefile);
+const char *disambiguate_fs(SourceFile *sourcefile);
 const char *disambiguate_h(SourceFile *sourcefile);
 const char *disambiguate_in(SourceFile *sourcefile);
 const char *disambiguate_inc(SourceFile *sourcefile);
@@ -29,6 +30,7 @@ basic, disambiguate_basic
 cs, disambiguate_cs
 def, disambiguate_def
 fortran, disambiguate_fortran
+fs, disambiguate_fs
 h, disambiguate_h
 in, disambiguate_in
 inc, disambiguate_inc

--- a/src/hash/extensions.gperf
+++ b/src/hash/extensions.gperf
@@ -79,7 +79,7 @@ for, DISAMBIGUATE("fortran")
 fpp, DISAMBIGUATE("fortran")
 frm, LANG_VISUALBASIC
 frx, LANG_VISUALBASIC
-fs, LANG_FSHARP
+fs, DISAMBIGUATE("fs")
 fth, LANG_FORTH
 ftn, DISAMBIGUATE("fortran")
 gemspec, LANG_RUBY

--- a/src/hash/extensions.gperf
+++ b/src/hash/extensions.gperf
@@ -74,11 +74,13 @@ f95, DISAMBIGUATE("fortran")
 factor, LANG_FACTOR
 fr, LANG_FORTH
 frag, LANG_GLSL
+frt, LANG_FORTH
 for, DISAMBIGUATE("fortran")
 fpp, DISAMBIGUATE("fortran")
 frm, LANG_VISUALBASIC
 frx, LANG_VISUALBASIC
 fs, LANG_FSHARP
+fth, LANG_FORTH
 ftn, DISAMBIGUATE("fortran")
 gemspec, LANG_RUBY
 gif, BINARY

--- a/test/detect_files/forth.fs
+++ b/test/detect_files/forth.fs
@@ -1,0 +1,7 @@
+\ Sample Forth code
+
+( This is a comment
+  spanning multiple lines )
+
+: somedefinition ;
+

--- a/test/expected_dir/forth.fs
+++ b/test/expected_dir/forth.fs
@@ -1,0 +1,7 @@
+forth	comment	\ Sample Forth code
+forth	blank	
+forth	comment	( This is a comment
+forth	comment	  spanning multiple lines )
+forth	blank	
+forth	code	: somedefinition ;
+forth	blank	

--- a/test/src_dir/forth.fs
+++ b/test/src_dir/forth.fs
@@ -1,0 +1,7 @@
+\ Sample Forth code
+
+( This is a comment
+  spanning multiple lines )
+
+: somedefinition ;
+

--- a/test/unit/detector_test.h
+++ b/test/unit/detector_test.h
@@ -145,6 +145,7 @@ void test_detector_detect_polyglot() {
   ASSERT_DETECT(LANG_FORTH, "forth.4th");
   ASSERT_DETECT(LANG_FORTH, "forth.fr");
   ASSERT_DETECT(LANG_FSHARP, "fs1.fs");
+  ASSERT_DETECT(LANG_FORTH, "forth.fs");
   ASSERT_DETECT(LANG_AUTOCONF, "m4.m4");
   ASSERT_DETECT(LANG_NSIS, "foo.nsi");
   ASSERT_DETECT(LANG_NSIS, "foo.nsh");


### PR DESCRIPTION
Adds disambiguation between Forth and F# for .fs files.  Also adds a few other common extensions for Forth source files.

The original version classifies all the .fs files in the Gforth repository (and other Forth repositories) as F#, while they actually contain Forth code.
