### PR TITLE
Fix incorrect comment pattern for objective_c detection

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -694,7 +694,7 @@ const char *disambiguate_m(SourceFile *sourcefile) {
         matlab_score++;
         octave_syntax_detected = 1;
       }
-    } else if (*p == '/' && *(p + 1) == '/' || *(p + 1) == '*') {
+    } else if (*p == '/' && *(p + 1) == '/' || *p == '/' && *(p + 1) == '*') {
       objective_c_score++; // Objective C comment
     } else if (*p == '+' || *p == '-') { // Objective C method signature
       objective_c_score++;


### PR DESCRIPTION
Objective_c comments always start with a **/**. The existing code matches the asterisk character in the second column of a line to decide that a file is objective_c. This leads it to detect mathematica comments "(*" as objective_c comments.
