### PR TITLE
Some fixes for building on Fedora

### DIFF
--- a/ruby/print_arch
+++ b/ruby/print_arch
@@ -3,13 +3,13 @@ require 'mkmf'
 
 arch = RbConfig::expand(CONFIG["arch"])
 
-distro = if File.exist?("/etc/issue")
+distro = if File.exist?("/etc/os-release")
   # this is "", "CentOS" or "Ubuntu"
-  `cat /etc/issue`.split.first.downcase
+  `egrep "^ID=.*" /etc/os-release`.split("=")[1].downcase
 end
 
 unless ["centos", nil, "ubuntu"].include? distro
-	STDERR.puts "unhandled /etc/issue result: #{distro}"
+	STDERR.puts "unhandled /etc/os-release result: #{distro}"
 end
 
 # either <arch> or <arch>_<distro> if distro is non-null

--- a/src/languages.h
+++ b/src/languages.h
@@ -119,6 +119,6 @@
 
 // For gperf.
 struct LanguageMap { const char *key; const char *name; const char *nice_name; int category; };
-struct LanguageMap *ohcount_hash_language_from_name(register const char *str, register unsigned int len);
+struct LanguageMap *ohcount_hash_language_from_name(register const char *str, register size_t len);
 
 #endif

--- a/src/parser.c
+++ b/src/parser.c
@@ -7,7 +7,7 @@
 #include "log.h"
 #include "hash/parser_hash.h"
 
-struct ParserMap * ohcount_hash_parser_from_language (register const char *str, register unsigned int len);
+struct ParserMap * ohcount_hash_parser_from_language (register const char *str, register size_t len);
 
 int ohcount_parse(SourceFile *sourcefile, int count,
                   void (*callback) (const char *, const char *, int, int,


### PR DESCRIPTION
Fix error caused from Fedora /etc/issue file containing `\S` escape sequence
```
unhandled /etc/issue result: \s
Building Ohcount

```
Fix compile error with different function signatures

languages.gperf:66:1: error: conflicting types for ‘ohcount_hash_language_from_name’
In file included from languages.gperf:2:0:
src/hash/../languages.h:122:21: note: previous declaration of ‘ohcount_hash_language_from_name’ was here
 struct LanguageMap *ohcount_hash_language_from_name(register const char *str, register unsigned int len);
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
