### PR TITLE
OTWO-5454 Fix php tag being identified as html

### DIFF
--- a/src/parsers/php.rl
+++ b/src/parsers/php.rl
@@ -41,6 +41,10 @@ enum {
       break;
     case NEWLINE:
       std_newline(PHP_LANG)
+      break;
+    case CHECK_BLANK_ENTRY:
+      check_blank_entry(PHP_LANG)
+      break;
     }
   }
 

--- a/src/parsers/phphtml.rl
+++ b/src/parsers/phphtml.rl
@@ -124,7 +124,7 @@ enum {
   phtml_php_entry = ('<?' 'php'?) @code;
   phtml_php_outry = '?>' @check_blank_outry @code;
   phtml_php_line := |*
-    phtml_php_outry @{ p = ts; fret; };
+    phtml_php_outry ${ p = ts; fret; };
     # unmodified PHP patterns
     spaces       ${ entity = PHP_SPACE; } => php_ccallback;
     php_comment;
@@ -138,7 +138,7 @@ enum {
       @{ saw(CSS_LANG); } => { fcall phtml_css_line; };
     phtml_js_entry @{ entity = CHECK_BLANK_ENTRY; } @phtml_ccallback
       @{ saw(JS_LANG); } => { fcall phtml_js_line; };
-    phtml_php_entry @{ entity = CHECK_BLANK_ENTRY; } @phtml_ccallback
+    phtml_php_entry @{ entity = CHECK_BLANK_ENTRY; } @php_ccallback
       @{ saw(PHP_LANG); } => { fcall phtml_php_line; };
     # standard PHTML patterns
     spaces       ${ entity = PHTML_SPACE; } => phtml_ccallback;

--- a/test/expected_dir/php1.php
+++ b/test/expected_dir/php1.php
@@ -22,7 +22,7 @@ html	code		<td>Email<td>
 html	code		</tr>
 html	code		</table>
 html	blank	
-html	code	<?
+php	code	<?php
 php	comment	## Comment with a hash symbol ##
 php	code		mysql_connect("localhost", "db user", "db pass")
 php	code		or die("DB CONNECT ERROR: " . mysql_error());
@@ -42,7 +42,7 @@ php	code			$fname = $row['fname'];
 php	code			$email = $row['email'];
 php	blank	
 php	comment			// Spaghetti code starts....(slopping html code in)
-html	code	?>
+php	code	>
 html	blank	
 html	code		<tr bgColor=white>
 php	code		<td><?=$fname?></td>
@@ -51,9 +51,9 @@ php	code		<td><?=$email?><td>
 html	code		</tr>
 html	code		</table>
 html	blank	
-html	code	<?
+php	code	<?
 php	code		} // end while
 php	comment		// Spaghetti code is both a source of praise and complaints
-html	code	?>
+php	code	>
 html	blank	
 html	code	</body>

--- a/test/src_dir/php1.php
+++ b/test/src_dir/php1.php
@@ -22,7 +22,7 @@
 	</tr>
 	</table>
 
-<?
+<?php
 ## Comment with a hash symbol ##
 	mysql_connect("localhost", "db user", "db pass")
 	or die("DB CONNECT ERROR: " . mysql_error());


### PR DESCRIPTION
The tests show that ohcount returns `>` instead of `?>`.
We haven't been able to fix this. However the line still counts as php, which serves our purpose.