### PR TITLE
Fix build on RHEL7

### DIFF
--- a/src/languages.h
+++ b/src/languages.h
@@ -126,6 +126,6 @@
 
 // For gperf.
 struct LanguageMap { const char *key; const char *name; const char *nice_name; int category; };
-struct LanguageMap *ohcount_hash_language_from_name(register const char *str, register size_t len);
+struct LanguageMap *ohcount_hash_language_from_name(register const char *str, register unsigned int len);
 
 #endif

--- a/src/parser.c
+++ b/src/parser.c
@@ -7,7 +7,7 @@
 #include "log.h"
 #include "hash/parser_hash.h"
 
-struct ParserMap * ohcount_hash_parser_from_language (register const char *str, register size_t len);
+struct ParserMap * ohcount_hash_parser_from_language (register const char *str, register unsigned int len);
 
 int ohcount_parse(SourceFile *sourcefile, int count,
                   void (*callback) (const char *, const char *, int, int,


### PR DESCRIPTION
Fix the following error during build:

```
languages.gperf:72:1: error: conflicting types for ‘ohcount_hash_language_from_name’
In file included from languages.gperf:2:0:
src/hash/../languages.h:129:21: note: previous declaration of ‘ohcount_hash_language_from_name’ was here
 struct LanguageMap *ohcount_hash_language_from_name(register const char *str, register size_t len);
```

I'm on RHEL7 7.3 with gcc 4.8.5. Maybe a newer gcc is lets `unsigned int` be used interchangeably with `size_t` ? 