### PR TITLE
Add support for Dart files

### DIFF
--- a/src/hash/extensions.gperf
+++ b/src/hash/extensions.gperf
@@ -51,6 +51,7 @@ ctp, LANG_PHP
 cu, LANG_CUDA
 cxx, LANG_CPP
 d, LANG_DMD
+dart, LANG_DART
 dat, DISAMBIGUATE("dat")
 def, DISAMBIGUATE("def")
 di, LANG_DMD

--- a/src/hash/languages.gperf
+++ b/src/hash/languages.gperf
@@ -32,6 +32,7 @@ cs_aspx, LANG_CS_ASPX, "", 0
 csharp, LANG_CSHARP, "C#", 0
 css, LANG_CSS, "CSS", 1
 cuda, LANG_CUDA, "CUDA", 0
+dart, LANG_DART, "Dart", 0
 dcl, LANG_DCL, "DCL", 0
 dmd, LANG_DMD, "D", 0
 dtx, LANG_TEX_DTX, "DTX for TeX/LaTeX", 1

--- a/src/hash/parsers.gperf
+++ b/src/hash/parsers.gperf
@@ -25,6 +25,7 @@
 #include "../parsers/css.h"
 #include "../parsers/d.h"
 #include "../parsers/dcl.h"
+#include "../parsers/dart.h"
 #include "../parsers/dylan.h"
 #include "../parsers/ebuild.h"
 #include "../parsers/eiffel.h"
@@ -135,6 +136,7 @@ cs_aspx, parse_cs_aspx
 csharp, parse_csharp
 css, parse_css
 cuda, parse_cuda
+dart, parse_dart
 dcl, parse_dcl
 dmd, parse_d
 dylan, parse_dylan

--- a/src/languages.h
+++ b/src/languages.h
@@ -34,6 +34,7 @@
 #define LANG_CSHARP "csharp"
 #define LANG_CSS "css"
 #define LANG_CUDA "cuda"
+#define LANG_DART "dart"
 #define LANG_DCL "dcl"
 #define LANG_DMD "dmd"
 #define LANG_DYLAN "dylan"

--- a/src/parsers/dart.rl
+++ b/src/parsers/dart.rl
@@ -1,0 +1,118 @@
+/************************* Required for every parser *************************/
+#ifndef OHCOUNT_DART_PARSER_H
+#define OHCOUNT_DART_PARSER_H
+
+#include "../parser_macros.h"
+
+// the name of the language
+const char *DART_LANG = LANG_DART;
+
+// the languages entities
+const char *dart_entities[] = {
+  "space", "comment", "any"
+};
+
+// constants associated with the entities
+enum {
+  DART_SPACE = 0, DART_COMMENT, DART_ANY
+};
+
+/*****************************************************************************/
+
+%%{
+  machine dart;
+  write data;
+  include common "common.rl";
+
+  # Line counting machine
+
+  action dart_ccallback {
+    switch(entity) {
+    case DART_SPACE:
+      ls
+      break;
+    case DART_ANY:
+      code
+      break;
+    case INTERNAL_NL:
+      std_internal_newline(DART_LANG)
+      break;
+    case NEWLINE:
+      std_newline(DART_LANG)
+    }
+  }
+
+  dart_line_comment =
+    '//' @comment (
+      escaped_newline %{ entity = INTERNAL_NL; } %dart_ccallback
+      |
+      ws
+      |
+      (nonnewline - ws) @comment
+    )*;
+  dart_block_comment =
+    '/*' @comment (
+      newline %{ entity = INTERNAL_NL; } %dart_ccallback
+      |
+      ws
+      |
+      (nonnewline - ws) @comment
+    )* :>> '*/';
+  dart_comment = dart_line_comment | dart_block_comment;
+
+  dart_line := |*
+    spaces    ${ entity = DART_SPACE; } => dart_ccallback;
+    dart_comment;
+    newline   ${ entity = NEWLINE; } => dart_ccallback;
+    ^space    ${ entity = DART_ANY;   } => dart_ccallback;
+  *|;
+
+  # Entity machine
+  # TODO: This is a placeholder and most entities are missing.
+
+  action dart_ecallback {
+    callback(DART_LANG, dart_entities[entity], cint(ts), cint(te), userdata);
+  }
+
+  dart_line_comment_entity = '//' (escaped_newline | nonnewline)*;
+  dart_block_comment_entity = '/*' any* :>> '*/';
+  dart_comment_entity = dart_line_comment_entity | dart_block_comment_entity;
+
+  dart_entity := |*
+    space+                 ${ entity = DART_SPACE;      } => dart_ecallback;
+    dart_comment_entity    ${ entity = DART_COMMENT;    } => dart_ecallback;
+    ^space;
+  *|;
+}%%
+
+/************************* Required for every parser *************************/
+
+/* Parses a string buffer with Dart code.
+ *
+ * @param *buffer The string to parse.
+ * @param length The length of the string to parse.
+ * @param count Integer flag specifying whether or not to count lines. If yes,
+ *   uses the Ragel machine optimized for counting. Otherwise uses the Ragel
+ *   machine optimized for returning entity positions.
+ * @param *callback Callback function. If count is set, callback is called for
+ *   every line of code, comment, or blank with 'lcode', 'lcomment', and
+ *   'lblank' respectively. Otherwise callback is called for each entity found.
+ */
+void parse_dart(char *buffer, int length, int count,
+             void (*callback) (const char *lang, const char *entity, int s,
+                               int e, void *udata),
+             void *userdata
+  ) {
+  init
+
+  %% write init;
+  cs = (count) ? dart_en_dart_line : dart_en_dart_entity;
+  %% write exec;
+
+  // if no newline at EOF; callback contents of last line
+  if (count) { process_last_line(DART_LANG) }
+}
+
+#endif
+
+/*****************************************************************************/

--- a/test/detect_files/foo.dart
+++ b/test/detect_files/foo.dart
@@ -1,0 +1,4 @@
+// Example Dart code
+void main() {
+  print("Hello, World!");
+}

--- a/test/expected_dir/foo.dart
+++ b/test/expected_dir/foo.dart
@@ -1,0 +1,9 @@
+dart	code	void main() {
+dart	comment	  // Line comment
+dart	blank	
+dart	comment	  /* Block
+dart	comment	     comment */
+dart	blank	
+dart	code	  print("Hello!"); // Code with line comment
+dart	code	  print("World!"); /* Code with block comment */
+dart	code	}

--- a/test/src_dir/foo.dart
+++ b/test/src_dir/foo.dart
@@ -1,0 +1,9 @@
+void main() {
+  // Line comment
+
+  /* Block
+     comment */
+
+  print("Hello!"); // Code with line comment
+  print("World!"); /* Code with block comment */
+}

--- a/test/unit/detector_test.h
+++ b/test/unit/detector_test.h
@@ -221,6 +221,10 @@ void test_detector_brainfuck() {
   ASSERT_DETECT(LANG_BFPP, "foo.bfpp");
 }
 
+void test_detector_dart() {
+  ASSERT_DETECT(LANG_DART, "foo.dart");
+}
+
 void test_detector_emacs_mode() {
 	ASSERT_DETECT(LANG_C, "emacs_mode_c");
 }
@@ -272,6 +276,7 @@ void all_detector_tests() {
   test_detector_basic();
   test_detector_xml_with_custom_extension();
   test_detector_brainfuck();
+  test_detector_dart();
   test_detector_emacs_mode();
   test_detector_emacs_with_extension();
   test_detector_puppet();

--- a/test/unit/parser_test.h
+++ b/test/unit/parser_test.h
@@ -98,6 +98,7 @@ void test_parser_verify_entity(SourceFile *sf, const char *entity,
 #include "parsers/test_csharp.h"
 #include "parsers/test_css.h"
 #include "parsers/test_d.h"
+#include "parsers/test_dart.h"
 #include "parsers/test_dcl.h"
 #include "parsers/test_dylan.h"
 #include "parsers/test_ebuild.h"
@@ -288,6 +289,7 @@ void all_parser_tests() {
   all_cs_aspx_tests();
   all_csharp_tests();
   all_css_tests();
+  all_dart_tests();
   all_dmd_tests();
   all_dcl_tests();
   all_dylan_tests();

--- a/test/unit/parsers/test_dart.h
+++ b/test/unit/parsers/test_dart.h
@@ -1,0 +1,39 @@
+
+void test_dart_comments() {
+  test_parser_verify_parse(
+    test_parser_sourcefile("dart", " //comment"),
+    "dart", "", "//comment", 0
+  );
+}
+
+void test_dart_empty_comments() {
+  test_parser_verify_parse(
+    test_parser_sourcefile("dart", " //\n"),
+    "dart", "", "//\n", 0
+  );
+}
+
+void test_dart_block_comment() {
+  test_parser_verify_parse(
+    test_parser_sourcefile("dart", "/*comment*/"),
+    "dart", "", "/*comment*/", 0
+  );
+}
+
+void test_dart_comment_entities() {
+  test_parser_verify_entity(
+    test_parser_sourcefile("dart", " //comment"),
+    "comment", "//comment"
+  );
+  test_parser_verify_entity(
+    test_parser_sourcefile("c", " /*comment*/"),
+    "comment", "/*comment*/"
+  );
+}
+
+void all_dart_tests() {
+  test_dart_comments();
+  test_dart_empty_comments();
+  test_dart_block_comment();
+  test_dart_comment_entities();
+}


### PR DESCRIPTION
I tried my best to follow the internal documentation and used the C and Ada parsers for reference. At the moment, only line counting is properly supported (like Ada). If detailed entity parsing is of high importance, please let me know. This should fix #74.